### PR TITLE
Using RbConfig instead of obsolete and deprecated Config.

### DIFF
--- a/lib/getpass.rb
+++ b/lib/getpass.rb
@@ -1,7 +1,7 @@
 require 'rbconfig'
 
 module Getpass
-  if Config::CONFIG['host_os'] =~ /mswin|mingw/
+  if RbConfig::CONFIG['host_os'] =~ /mswin|mingw/
     require 'Win32API'
     @@_getch = Win32API.new('crtdll', '_getch', [], 'L')
     @@_kbhit = Win32API.new('crtdll', '_kbhit', [], 'L')

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -8,7 +8,7 @@ class GetpassTest < Test::Unit::TestCase
     char.is_a?(Fixnum) ? char : char[0].ord
   end
 
-  if Config::CONFIG['host_os'] =~ /mswin|mingw/
+  if RbConfig::CONFIG['host_os'] =~ /mswin|mingw/
     require "Win32API"
     @@_ungetch = Win32API.new('crtdll', '_ungetch', [], 'L')
 


### PR DESCRIPTION
The standard module Config has been deprecated, and has been replaced by RbConfig.
